### PR TITLE
Updated javaHecLib DLL to stay in sync with WRIMS

### DIFF
--- a/system-summary-report-tool-install/build.gradle
+++ b/system-summary-report-tool-install/build.gradle
@@ -8,7 +8,7 @@ plugins {
 
 dependencies {
     implementation(project(":system-summary-report-tool"))
-    runtimeOnly 'mil.army.usace.hec:javaHeclib:7-IS-2-win-x86_64@zip'
+    runtimeOnly 'mil.army.usace.hec:javaHeclib:7-IU-4-win-x86_64@zip'
 }
 
 task extractDll(type: Copy) {

--- a/system-summary-report-tool/build.gradle
+++ b/system-summary-report-tool/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     implementation libs.itextpdf
     implementation libs.itexthyphxml
     implementation libs.dsm2inputmodel
-    runtimeOnly 'mil.army.usace.hec:javaHeclib:7-IS-2-win-x86_64@zip'
+    runtimeOnly 'mil.army.usace.hec:javaHeclib:7-IU-4-win-x86_64@zip'
 }
 
 publishing {


### PR DESCRIPTION
Updating the runtime javaHecLib DLL to match WRIMS