### PR TITLE
Removing deprecated DSS setDefaultDPart method. Updating hec-monolith.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-hec-monolith = "5.3.5"
+hec-monolith = "6.0.0"
 pdf-renderer = "1.0.5"
 dom4j = "1.6.1"
 crimson = "1.1.3"

--- a/system-summary-report-tool/src/main/java/gov/ca/dwr/callite/Report.java
+++ b/system-summary-report-tool/src/main/java/gov/ca/dwr/callite/Report.java
@@ -169,8 +169,7 @@ public class Report {
 			return;}
 		String baseAPart = basePaths[0].split("/")[1];
 		String baseFPart = basePaths[0].split("/")[6];
-		DSSPathname.setDefaultDPart(basePaths[0].split("/")[4]);
-
+        
 		HecTimeSeries htsAlt = new HecTimeSeries(scalars.get("FILE_ALT"));
 		htsAlt.setRetrieveAllTimes(true);
 		String[] altPaths = htsAlt.getCatalog(false);


### PR DESCRIPTION
Identified old usage of hecmonolith that triggered missing function in comparison report when running comparison tests. 