### PR TITLE
Restore EPPT-style Y-axis label semantics

### DIFF
--- a/system-summary-report-tool/src/main/java/gov/ca/water/ssrt/Report.java
+++ b/system-summary-report-tool/src/main/java/gov/ca/water/ssrt/Report.java
@@ -253,7 +253,7 @@ public class Report {
 				tscAlt=Utils.taf2cfs(tscAlt);
 			}
 			String data_units = tscBase.units;
-			String data_type = tscBase.parameter;
+			String data_type = Utils.getYAxisLabelType(tscBase);
 			validator.evaluateTimeSeriesDiff(tscAlt, tscBase, pathMap.var_name, tw);
 			if (pathMap.plot) {
 				if (pathMap.report_type.startsWith("average")) {

--- a/system-summary-report-tool/src/main/java/gov/ca/water/ssrt/Utils.java
+++ b/system-summary-report-tool/src/main/java/gov/ca/water/ssrt/Utils.java
@@ -179,8 +179,9 @@ public class Utils {
 		}
 	}
     public static String getYAxisLabelType(TimeSeriesContainer tsc) {
+        String defaultLabel = "VARIABLE VALUE";
         if (tsc == null) {
-            return "";
+            return defaultLabel;
         }
 
         try {
@@ -203,7 +204,7 @@ public class Utils {
             return tsc.type;
         }
 
-        return "";
+        return defaultLabel;
     }
 	public static String getExceedancePlotTitle(PathnameMap path_map) {
 		String title = "Exceedance " + path_map.var_name.replace("\"", "");

--- a/system-summary-report-tool/src/main/java/gov/ca/water/ssrt/Utils.java
+++ b/system-summary-report-tool/src/main/java/gov/ca/water/ssrt/Utils.java
@@ -178,7 +178,33 @@ public class Utils {
 			return getTypeOfReference(tsc1);
 		}
 	}
+    public static String getYAxisLabelType(TimeSeriesContainer tsc) {
+        if (tsc == null) {
+            return "";
+        }
 
+        try {
+            String cPart = new DSSPathname(tsc.fullName).getCPart();
+            if (cPart != null) {
+                cPart = cPart.trim();
+                if (!cPart.isEmpty() && !"-".equals(cPart)) {
+                    return cPart;
+                }
+            }
+        } catch (Exception e) {
+            // Ignore malformed or incomplete paths and fall back below.
+        }
+
+        if (tsc.parameter != null && !tsc.parameter.isBlank()) {
+            return tsc.parameter;
+        }
+
+        if (tsc.type != null && !tsc.type.isBlank()) {
+            return tsc.type;
+        }
+
+        return "";
+    }
 	public static String getExceedancePlotTitle(PathnameMap path_map) {
 		String title = "Exceedance " + path_map.var_name.replace("\"", "");
 		if (path_map.var_category.equalsIgnoreCase("S_Jan")) {


### PR DESCRIPTION
This PR restores historical EPPT-style Y-axis label semantics by changing how current Y-axis labels are derived. 

Previously, labels were derived directly from TimeSeriesContainer.parameter. 

This change introduces a centralized helper method that prefers using the more meaningful DSS pathname Part C.